### PR TITLE
Update motion-kit version lock.

### DIFF
--- a/sweet-kit.gemspec
+++ b/sweet-kit.gemspec
@@ -23,6 +23,6 @@ DESC
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'motion-kit', '~> 0.12.0'
+  spec.add_dependency 'motion-kit', '~> 0.17.0'
   spec.add_dependency 'sugarcube'
 end


### PR DESCRIPTION
This fixes a bundle error I had when trying to use the latest `motion-kit` and `sweet-kit`.

```
Bundler could not find compatible versions for gem "motion-kit":
  In Gemfile:
    sweet-kit (>= 0) ruby depends on
      motion-kit (~> 0.12.0) ruby

    motion-kit (0.17.0)
```