### PR TITLE
Fix rename warning

### DIFF
--- a/lib/sweet-kit.rb
+++ b/lib/sweet-kit.rb
@@ -9,7 +9,7 @@ require 'motion-kit'
 require 'sugarcube'
 platform = App.template
 if platform == :ios
-  require 'sugarcube-uikit'
+  require 'sugarcube-ui'
 elsif platform == :osx
   require 'sugarcube-appkit'
 end


### PR DESCRIPTION
This fixes a `'sugarcube-uikit' has been renamed to (platform agnostic) 'sugarcube-ui'` warning. 
